### PR TITLE
Drop argument name in declaration.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ This code creates a scalable network of cells and runs a simulation.
 It models the rat CA1 using several cell types and can include
 characteristics of an epileptic network (sprouting and cell death).
 
+UPDATES
+- 2022-04-01: sgate.mod: patch for compatibility with NEURON > 8.1. Technical fix, no expected changes.
+
 INSTRUCTIONS FOR RUNNING THE PROGRAM
 >SETUP:
 1. Ensure neuron is installed on the head node and has its directory added to PATH

--- a/sgate.mod
+++ b/sgate.mod
@@ -74,7 +74,7 @@ PROCEDURE seed(x) {
 }
 
 VERBATIM
-double nrn_random_pick(void* r);
+double nrn_random_pick(void*);
 void* nrn_random_arg(int argpos);
 ENDVERBATIM
 


### PR DESCRIPTION
`r` is a variable name from the ASSIGNED block, which means that nocmodl defines it as a preprocessor macro expanding to `_p[9]`, which in turn means the declared argument type is `void**`, not `void*`.

This causes an error when this model is tested against https://github.com/neuronsimulator/nrn/pull/1755, as described in https://github.com/neuronsimulator/nrn/pull/1755#issuecomment-1084492976.

cc: @ramcdougal